### PR TITLE
Update to Zeebe 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>Zeebe HTTP Worker</name>
     <groupId>io.zeebe</groupId>
     <artifactId>zeebe-http-worker</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -16,8 +16,8 @@
     </parent>
 
     <properties>
-        <version.zeebe>0.26.1</version.zeebe>
-        <version.zeebe.spring>0.26.2</version.zeebe.spring>
+        <version.zeebe>1.0.1</version.zeebe>
+        <version.zeebe.spring>1.0.0</version.zeebe.spring>
         <version.spring.boot>2.4.3</version.spring.boot>
 
         <!-- release parent settings -->
@@ -35,7 +35,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.zeebe</groupId>
+                <groupId>io.camunda</groupId>
                 <artifactId>zeebe-bom</artifactId>
                 <version>${version.zeebe}</version>
                 <scope>import</scope>
@@ -53,7 +53,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zeebe.spring</groupId>
+            <groupId>io.camunda</groupId>
             <artifactId>spring-zeebe-starter</artifactId>
             <version>${version.zeebe.spring}</version>
         </dependency>
@@ -96,16 +96,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.zeebe</groupId>
+            <groupId>io.camunda</groupId>
             <artifactId>zeebe-test</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.zeebe</groupId>
-            <artifactId>zeebe-test-container</artifactId>
-            <scope>test</scope>
-            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/zeebe/http/ConfigurationMaps.java
+++ b/src/main/java/io/zeebe/http/ConfigurationMaps.java
@@ -1,7 +1,6 @@
 package io.zeebe.http;
 
-import io.zeebe.client.api.response.ActivatedJob;
-
+import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -41,7 +40,7 @@ public class ConfigurationMaps {
     config.putAll(environmentVariables);
 
     config.put("jobKey", job.getKey());
-    config.put("workflowInstanceKey", job.getWorkflowInstanceKey());
+    config.put("processInstanceKey", job.getProcessInstanceKey());
   }
 
   public Optional<Object> get(String key) {

--- a/src/main/java/io/zeebe/http/HttpJobHandler.java
+++ b/src/main/java/io/zeebe/http/HttpJobHandler.java
@@ -15,6 +15,9 @@
  */
 package io.zeebe.http;
 
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.api.worker.JobHandler;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -36,10 +39,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-
-import io.zeebe.client.api.response.ActivatedJob;
-import io.zeebe.client.api.worker.JobClient;
-import io.zeebe.client.api.worker.JobHandler;
 
 @Component
 public class HttpJobHandler implements JobHandler {

--- a/src/main/java/io/zeebe/http/ZeebeHttpWorkerApplication.java
+++ b/src/main/java/io/zeebe/http/ZeebeHttpWorkerApplication.java
@@ -15,6 +15,10 @@
  */
 package io.zeebe.http;
 
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.spring.client.EnableZeebeClient;
+import io.camunda.zeebe.spring.client.annotation.ZeebeWorker;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -24,11 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
-
-import io.zeebe.client.api.response.ActivatedJob;
-import io.zeebe.client.api.worker.JobClient;
-import io.zeebe.spring.client.EnableZeebeClient;
-import io.zeebe.spring.client.annotation.ZeebeWorker;
 
 @SpringBootApplication
 @EnableZeebeClient


### PR DESCRIPTION
* dump `spring-zeebe-starter` from `0.26.2` to `1.0.0`
* dump `zeebe-bom` from `0.26.1` to `1.0.1`
* update and align the worker to Zeebe 1.0.0
* rename the context property from `workflowInstanceKey` to `processInstanceKey`