### PR TITLE
feat(mime-type): Can accept text/plain response content type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea/
 .vscode/
+.classpath
+.project
+.settings/
 target/*
 coverage*
 dist/


### PR DESCRIPTION
The current worker can only implicitely accept "application/json" content type hence it'll throw an error if any other type is being returned: "Failed to deserialize response body from JSON".

Having a use case where some web service is returning some plain text, I extended the headers management to handle at least these two content types.