### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <repository>
             <id>zeebe</id>
             <name>Zeebe Repository</name>
-            <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -215,7 +215,7 @@
         <repository>
             <id>zeebe-snapshots</id>
             <name>Zeebe Snapshot Repository</name>
-            <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
We created a new domain name for our repository manager (Artifactory) to replace the old Nexus proxy URL (app.camunda.com/nexus). The proxy URL will be removed in the future. 

Related to INFRA-3114



