### PR TITLE
Migrate to Zeebe-Spring-Test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Java setup
       uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Cache
       uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Java environment
       uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
       with:
-        java-version: 11
+        java-version: 17
         gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
         gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
     - name: Login to Docker

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,11 @@
     </parent>
 
     <properties>
-        <version.zeebe>1.3.6</version.zeebe>
-        <version.zeebe.spring>1.3.4</version.zeebe.spring>
-        <version.spring.boot>2.6.5</version.spring.boot>
+        <version.zeebe.spring>8.0.3</version.zeebe.spring>
+        <version.spring.boot>2.6.4</version.spring.boot>
 
         <!-- release parent settings -->
-        <version.java>11</version.java>
+        <version.java>17</version.java>
         <java.version>${version.java}</java.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -34,13 +33,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.camunda</groupId>
-                <artifactId>zeebe-bom</artifactId>
-                <version>${version.zeebe}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -58,12 +50,15 @@
             <version>${version.zeebe.spring}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
+            <groupId>io.camunda</groupId>
+            <artifactId>spring-zeebe-test</artifactId>
+            <version>${version.zeebe.spring}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <groupId>io.camunda</groupId>
+            <artifactId>spring-zeebe-test-testcontainer</artifactId>
+            <version>${version.zeebe.spring}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -96,15 +91,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.camunda</groupId>
-            <artifactId>zeebe-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.32.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -112,6 +101,19 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.1.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -164,8 +166,16 @@
                     </container>
                 </configuration>
             </plugin>
-
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M6</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>

--- a/src/main/java/io/zeebe/http/ZeebeHttpWorkerApplication.java
+++ b/src/main/java/io/zeebe/http/ZeebeHttpWorkerApplication.java
@@ -20,35 +20,29 @@ import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.spring.client.EnableZeebeClient;
 import io.camunda.zeebe.spring.client.annotation.ZeebeWorker;
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
 @EnableZeebeClient
-public class ZeebeHttpWorkerApplication extends SpringBootServletInitializer {
+public class ZeebeHttpWorkerApplication {
+
+  @Autowired
+  private HttpJobHandler jobHandler;
 
   public static void main(String[] args) {
     SpringApplication.run(ZeebeHttpWorkerApplication.class, args);
-    try {
-      new CountDownLatch(1).await();
-    } catch (InterruptedException e) {
-    }
   }
-  
-  @Autowired
-  private HttpJobHandler jobHandler;
 
   // This code does not limit the variables resolves
   // That means the worker always fetches all variables to support expressions/placeholders
   // as a workaround until https://github.com/zeebe-io/zeebe/issues/3417 is there
   @ZeebeWorker
-  public void handleFooJob(final JobClient client, final ActivatedJob job) throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  public void handleFooJob(final JobClient client, final ActivatedJob job)
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
     jobHandler.handle(client, job);
-  }  
+  }
 }

--- a/src/main/java/io/zeebe/http/variables/RemoteEnvironmentVariablesProvider.java
+++ b/src/main/java/io/zeebe/http/variables/RemoteEnvironmentVariablesProvider.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.PostConstruct;
 
 /**
  * Helper to load environment variables from a configured URL as JSON map.
@@ -46,8 +47,6 @@ public class RemoteEnvironmentVariablesProvider implements EnvironmentVariablesP
 
   protected RemoteEnvironmentVariablesProvider(ZeebeHttpWorkerConfig config) {
     this.config = config;
-    // Make sure that variable URL is already checked during worker startup
-    getVariables();
   }
 
   public Map<String, String> getVariables() {

--- a/src/test/java/io/zeebe/http/ProcessIntegrationTest.java
+++ b/src/test/java/io/zeebe/http/ProcessIntegrationTest.java
@@ -14,47 +14,58 @@ import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.filters.RecordStream;
+import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.test.ZeebeTestRule;
-import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import io.camunda.zeebe.spring.test.ZeebeTestThreadSupport;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
+@WireMockTest(httpPort = 8089)
 @SpringBootTest(
     properties = {
-      "ENV_VARS_URL=http://localhost:8089/config",
-      "ENV_VARS_RELOAD_RATE=0",
-      "ENV_VARS_M2M_BASE_URL:http://localhost:8089/token",
-      "ENV_VARS_M2M_CLIENT_ID:someClientId",
-      "ENV_VARS_M2M_CLIENT_SECRET:someSecret",
-      "ENV_VARS_M2M_AUDIENCE:someAudience"
+        "ENV_VARS_URL=http://localhost:8089/config",
+        "ENV_VARS_RELOAD_RATE=0",
+        "ENV_VARS_M2M_BASE_URL:http://localhost:8089/token",
+        "ENV_VARS_M2M_CLIENT_ID:someClientId",
+        "ENV_VARS_M2M_CLIENT_SECRET:someSecret",
+        "ENV_VARS_M2M_AUDIENCE:someAudience"
     })
+@ZeebeSpringTest
 public class ProcessIntegrationTest {
 
-  @ClassRule public static final ZeebeTestRule TEST_RULE = new ZeebeTestRule();
+  @Autowired
+  private ZeebeClient client;
 
-  @ClassRule public static WireMockRule WIRE_MOCK_RULE = new WireMockRule(8089);
+  @Autowired
+  private ZeebeTestEngine zeebeTestEngine;
 
-  @BeforeClass
-  public static void init() {
+  @BeforeEach
+  public void configureApiMock(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(
         get(urlEqualTo("/config"))
             .willReturn(aResponse().withHeader("Content-Type", "application/json").withBody("[]")));
@@ -66,18 +77,10 @@ public class ProcessIntegrationTest {
                     .withBody(
                         "{ \"token_type\": \"Bearer\", \"access_token\": \"TOKEN_123_42\" }")));
 
-    System.setProperty(
-        "zeebe.client.broker.contactPoint",
-        TEST_RULE.getClient().getConfiguration().getGatewayAddress());
-  }
-
-  @Before
-  public void resetMock() {
-    WIRE_MOCK_RULE.resetRequests();
   }
 
   @Test
-  public void testGetRequest() {
+  public void testGetRequest(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(
         get(urlEqualTo("/api"))
@@ -88,47 +91,51 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "GET"),
             Collections.emptyMap());
 
-    ZeebeTestRule.assertThat(processInstance)
-        .isEnded()
-        .hasVariable("statusCode", 200)
-        .hasVariable("body", Map.of("x", 1));
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(getRequestedFor(urlEqualTo("/api")));
+    BpmnAssert.assertThat(processInstance)
+        .isCompleted()
+        .hasVariableWithValue("statusCode", 200)
+        .hasVariableWithValue("body", Map.of("x", 1));
+
+    verify(getRequestedFor(urlEqualTo("/api")));
   }
 
   @Test
-  public void testGetAcceptPlainTextResponse() {
+  public void testGetAcceptPlainTextResponse(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(
         get(urlEqualTo("/api"))
             .willReturn(
                 aResponse().withHeader("Content-Type", "text/plain")
-                .withBody("This is text")));
+                    .withBody("This is text")));
 
     final var processInstance =
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "GET")
                     .zeebeTaskHeader("accept", "text/plain"),
             Collections.emptyMap());
 
-    ZeebeTestRule.assertThat(processInstance)
-        .isEnded()
-        .hasVariable("statusCode", 200)
-        .hasVariable("body", "This is text");
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(getRequestedFor(urlEqualTo("/api"))
+    BpmnAssert.assertThat(processInstance)
+        .isCompleted()
+        .hasVariableWithValue("statusCode", 200)
+        .hasVariableWithValue("body", "This is text");
+
+    verify(getRequestedFor(urlEqualTo("/api"))
         .withHeader("Accept", equalTo("text/plain")));
   }
 
   @Test
-  public void testPostContentTypePlainText() {
+  public void testPostContentTypePlainText(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(
         post(urlEqualTo("/api"))
             .willReturn(aResponse().withStatus(200)));
@@ -137,23 +144,25 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("contentType", "text/plain"),
             Map.of("body", "This is text"));
 
-    ZeebeTestRule.assertThat(processInstance)
-        .isEnded()
-        .hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance)
+        .isCompleted()
+        .hasVariableWithValue("statusCode", 200);
+
+    verify(
         postRequestedFor(urlEqualTo("/api"))
             .withHeader("Content-Type", equalTo("text/plain"))
             .withRequestBody(equalTo("This is text")));
   }
 
   @Test
-  public void testPostRequest() {
+  public void testPostRequest(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(201)));
 
@@ -161,20 +170,22 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "POST"),
             Map.of("body", Map.of("x", 1)));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 201);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 201);
+
+    verify(
         postRequestedFor(urlEqualTo("/api"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson("{\"x\":1}")));
   }
 
   @Test
-  public void testPutRequest() {
+  public void testPutRequest(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(put(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
 
@@ -182,20 +193,22 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "PUT"),
             Map.of("body", Map.of("x", 1)));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 200);
+
+    verify(
         putRequestedFor(urlEqualTo("/api"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson("{\"x\":1}")));
   }
 
   @Test
-  public void testHeaderNamesCanBeUpperAsWell() {
+  public void testHeaderNamesCanBeUpperAsWell(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(put(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
 
@@ -203,16 +216,18 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("URL", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("URL", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("METHOD", "PUT")
                     .zeebeTaskHeader("ACCEPT", "text/plain")
                     .zeebeTaskHeader("CONTENTTYPE", "application/json")
                     .zeebeTaskHeader("AUTHORIZATION", "secret"),
             Map.of("body", Map.of("x", 1)));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 200);
+
+    verify(
         putRequestedFor(urlEqualTo("/api"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("Authorization", equalTo("secret"))
@@ -221,7 +236,7 @@ public class ProcessIntegrationTest {
   }
 
   @Test
-  public void testDeleteRequest() {
+  public void testDeleteRequest(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(delete(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
 
@@ -229,17 +244,19 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "DELETE"),
             Collections.emptyMap());
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(deleteRequestedFor(urlEqualTo("/api")));
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 200);
+
+    verify(deleteRequestedFor(urlEqualTo("/api")));
   }
 
   @Test
-  public void testGetNotFoundResponse() {
+  public void testGetNotFoundResponse(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(get(urlEqualTo("/api")).willReturn(aResponse().withStatus(404)));
 
@@ -247,17 +264,20 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("statusCodeFailure", "400,401,402,403,405")
                     .zeebeTaskHeader("statusCodeCompletion", "404")
                     .zeebeTaskHeader("method", "GET"),
             Map.of());
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 404);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
+
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 404);
   }
 
   @Test
-  public void testGetRequestDelayedResponse() throws InterruptedException {
+  public void testGetRequestDelayedResponse(WireMockRuntimeInfo wmRuntimeInfo)
+      throws InterruptedException {
     long originalResponseTimeout = HttpJobHandler.RESPONSE_TIMEOUT_VALUE;
     try {
       HttpJobHandler.RESPONSE_TIMEOUT_VALUE = 2; // 2 seconds
@@ -286,7 +306,7 @@ public class ProcessIntegrationTest {
           createInstance(
               serviceTask ->
                   serviceTask
-                      .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                      .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                       .zeebeTaskHeader("method", "GET")
                       .zeebeJobRetries("3"),
               Collections.emptyMap());
@@ -294,16 +314,18 @@ public class ProcessIntegrationTest {
       // TODO: Think about a better way of doing this :-)
       Thread.sleep(3 * 1000);
 
-      ZeebeTestRule.assertThat(processInstance).isEnded();
+      ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-      WIRE_MOCK_RULE.verify(2, getRequestedFor(urlEqualTo("/api")));
+      BpmnAssert.assertThat(processInstance).isCompleted();
+
+      verify(2, getRequestedFor(urlEqualTo("/api")));
     } finally {
       HttpJobHandler.RESPONSE_TIMEOUT_VALUE = originalResponseTimeout;
     }
   }
 
   @Test
-  public void testAuthorizationHeader() {
+  public void testAuthorizationHeader(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(get(urlEqualTo("/api")).willReturn(aResponse()));
 
@@ -311,18 +333,20 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "GET"),
             Map.of("authorization", "token 123"));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 200);
+
+    verify(
         getRequestedFor(urlEqualTo("/api")).withHeader("Authorization", equalTo("token 123")));
   }
 
   @Test
-  public void testCustomHeader() {
+  public void testCustomHeader(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(get(urlEqualTo("/api")).willReturn(aResponse()));
 
@@ -330,84 +354,103 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "GET"),
             Map.of("header-X-API-Key", "top-secret"));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 200);
+
+    verify(
         getRequestedFor(urlEqualTo("/api")).withHeader("X-API-Key", equalTo("top-secret")));
   }
 
   @Test
-  public void shouldExposeJobKeyIfStatusCode202() {
+  public void shouldExposeJobKeyIfStatusCode202(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(202)));
 
     final var processInstance =
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("statusCodeCompletion", "200,201,203,204,205,206") // NO 202!!
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("body", "{\"jobKey\":\"{{jobKey}}\"}"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+          final var recorderJob = StreamFilter.jobRecords(
+                  RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.CREATED)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst()
+              .orElseThrow();
 
-    // simulate an async callback
-    TEST_RULE.getClient().newCompleteCommand(recorderJob.getKey()).send().join();
+          // simulate an async callback
+          client.newCompleteCommand(recorderJob.getKey()).send().join();
 
-    ZeebeTestRule.assertThat(processInstance).isEnded();
+      verify(
+          postRequestedFor(urlEqualTo("/api"))
+              .withRequestBody(equalToJson("{\"jobKey\":\"" + recorderJob.getKey() + "\"}")));
+    });
 
-    WIRE_MOCK_RULE.verify(
-        postRequestedFor(urlEqualTo("/api"))
-            .withRequestBody(equalToJson("{\"jobKey\":\"" + recorderJob.getKey() + "\"}")));
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
+
+    BpmnAssert.assertThat(processInstance).isCompleted();
   }
 
   @Test
-  public void failOnHttpStatus400() {
+  public void failOnHttpStatus400(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(400)));
 
     final var processInstance =
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "POST"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.FAILED)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+      final var recorderJob =
+          StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.FAILED)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst().orElseThrow();
 
-    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 400");
+      Assertions.assertThat(recorderJob.getValue().getErrorMessage()).isNotNull()
+          .contains("failed with 400");
+    });
   }
 
   @Test
-  public void failOnHttpStatus500() {
+  public void failOnHttpStatus500(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(500)));
 
     final var processInstance =
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "POST"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.FAILED)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+      final var recorderJob =
+          StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.FAILED)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst().orElseThrow();
 
-    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 500");
+      Assertions.assertThat(recorderJob.getValue().getErrorMessage()).isNotNull()
+          .contains("failed with 500");
+    });
   }
 
   @Test
-  public void throwErrorCodeWithMessageOnFailure() {
+  public void throwErrorCodeWithMessageOnFailure(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(
         post(urlEqualTo("/api"))
             .willReturn(
@@ -420,22 +463,27 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("errorCodePath", "error.code")
                     .zeebeTaskHeader("errorMessagePath", "error.message")
                     .zeebeTaskHeader("method", "POST"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.ERROR_THROWN)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+      final var recorderJob =
+          StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.ERROR_THROWN)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst().orElseThrow();
 
-    assertThat(recorderJob.getValue().getErrorCode()).isNotNull().isEqualTo("some-code");
-    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().isEqualTo("some message");
+      Assertions.assertThat(recorderJob.getValue().getErrorCode()).isNotNull().isEqualTo("some-code");
+      Assertions.assertThat(recorderJob.getValue().getErrorMessage()).isNotNull()
+          .isEqualTo("some message");
+    });
   }
 
   @Test
-  public void throwErrorCodeWithEmptyMessageOnFailure() {
+  public void throwErrorCodeWithEmptyMessageOnFailure(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(
         post(urlEqualTo("/api"))
             .willReturn(
@@ -445,22 +493,28 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("errorCodePath", "error.code")
                     .zeebeTaskHeader("errorMessagePath", "error.message")
                     .zeebeTaskHeader("method", "POST"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.ERROR_THROWN)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+      final var recorderJob =
+          StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.ERROR_THROWN)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst().orElseThrow();
 
-    assertThat(recorderJob.getValue().getErrorCode()).isNotNull().isEqualTo("some-code");
-    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 400");
+      Assertions.assertThat(recorderJob.getValue().getErrorCode()).isNotNull()
+          .isEqualTo("some-code");
+      Assertions.assertThat(recorderJob.getValue().getErrorMessage()).isNotNull()
+          .contains("failed with 400");
+    });
   }
 
   @Test
-  public void failIfErrorCodeIsNotPresent() {
+  public void failIfErrorCodeIsNotPresent(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(
         post(urlEqualTo("/api"))
             .willReturn(
@@ -472,21 +526,26 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("errorCodePath", "error.code")
                     .zeebeTaskHeader("errorMessagePath", "error.message")
                     .zeebeTaskHeader("method", "POST"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.FAILED)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+      final var recorderJob =
+          StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.FAILED)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst().orElseThrow();
 
-    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("some message");
+      Assertions.assertThat(recorderJob.getValue().getErrorMessage()).isNotNull()
+          .contains("some message");
+    });
   }
 
   @Test
-  public void failIfBodyIsNotValidJson() {
+  public void failIfBodyIsNotValidJson(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(
         post(urlEqualTo("/api"))
             .willReturn(aResponse().withStatus(400).withBody("{error.code = some code}")));
@@ -495,21 +554,26 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("errorCodePath", "error.code")
                     .zeebeTaskHeader("errorMessagePath", "error.message")
                     .zeebeTaskHeader("method", "POST"));
 
-    final var recorderJob =
-        RecordingExporter.jobRecords(JobIntent.FAILED)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+    Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+      final var recorderJob =
+          StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+              .withIntent(JobIntent.FAILED)
+              .stream().filter(
+                  r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+              .findFirst().orElseThrow();
 
-    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 400");
+      Assertions.assertThat(recorderJob.getValue().getErrorMessage()).isNotNull()
+          .contains("failed with 400");
+    });
   }
 
   @Test
-  public void shouldReplacePlaceholdersWithVariables() {
+  public void shouldReplacePlaceholdersWithVariables(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(post(urlMatching("/api/.*")).willReturn(aResponse().withStatus(201)));
 
@@ -517,39 +581,43 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api/{{x}}")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api/{{x}}")
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("body", "{\"y\":{{y}}}"),
             Map.of("x", 1, "y", 2));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 201);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 201);
+
+    verify(
         postRequestedFor(urlEqualTo("/api/1"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson("{\"y\":2}")));
   }
 
   @Test
-  public void shouldReplaceLegacyPlaceholders() {
+  public void shouldReplaceLegacyPlaceholders(WireMockRuntimeInfo wmRuntimeInfo) {
     stubFor(post(urlMatching("/api/.*")).willReturn(aResponse().withStatus(201)));
 
     final var processInstance =
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api/{{x}}")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api/{{x}}")
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("body", "{\"y\":${y}}"),
             Map.of("x", 1, "y", 2));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 201);
-    WIRE_MOCK_RULE.verify(
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
+
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 201);
+    verify(
         postRequestedFor(urlEqualTo("/api/1")).withRequestBody(equalToJson("{\"y\":2}")));
   }
 
   @Test
-  public void shouldReplacePlaceholdersWithContext() {
+  public void shouldReplacePlaceholdersWithContext(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(post(urlMatching("/api/.*")).willReturn(aResponse().withStatus(201)));
 
@@ -557,19 +625,23 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api/{{jobKey}}")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api/{{jobKey}}")
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("body", "{\"instanceKey\":{{processInstanceKey}}}"),
             Map.of());
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 201);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
+
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 201);
 
     final var job =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
-            .getFirst();
+        StreamFilter.jobRecords(RecordStream.of(zeebeTestEngine.getRecordStreamSource()))
+            .withIntent(JobIntent.CREATED)
+            .stream().filter(
+                r -> r.getValue().getProcessInstanceKey() == processInstance.getProcessInstanceKey())
+            .findFirst().orElseThrow();
 
-    WIRE_MOCK_RULE.verify(
+    verify(
         postRequestedFor(urlEqualTo("/api/" + job.getKey()))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(
@@ -578,7 +650,8 @@ public class ProcessIntegrationTest {
   }
 
   @Test
-  public void shouldReplacePlaceholdersWithConfigVariablesWithM2MToken() {
+  public void shouldReplacePlaceholdersWithConfigVariablesWithM2MToken(
+      WireMockRuntimeInfo wmRuntimeInfo) {
     //    WIRE_MOCK_RULE.resetAll(); // forget the defaults set in the static initializer for this
     // test
     //    stubFor(post(urlEqualTo("/token")).willReturn(aResponse()
@@ -597,29 +670,32 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api/{{x}}")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api/{{x}}")
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("body", "{\"y\":{{y}}}"),
             Map.of());
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 201);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
+
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 201);
 
     // I can't check if the /token was called here, as the token is typically already cached from
     // other test runs
     // and I can't move this to a seperate test class because of limitations in the test support
     // from zeebe at the moment
     // So I check if the Authorization Header is set correctly instead
-    WIRE_MOCK_RULE.verify(
+    verify(
         getRequestedFor(urlEqualTo("/config"))
             .withHeader("Authorization", equalTo("Bearer TOKEN_123_42")));
-    WIRE_MOCK_RULE.verify(
+    verify(
         postRequestedFor(urlEqualTo("/api/1"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson("{\"y\":2}")));
   }
 
   @Test
-  public void shouldReplacePlaceholdersWithConfigVariablesWithM2MTokenRefresh() {
+  public void shouldReplacePlaceholdersWithConfigVariablesWithM2MTokenRefresh(
+      WireMockRuntimeInfo wmRuntimeInfo) {
     // forbidden, which happens because of outdated tokens
     stubFor(
         get(urlMatching("/config"))
@@ -644,14 +720,16 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api/{{x}}")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api/{{x}}")
                     .zeebeTaskHeader("method", "POST")
                     .zeebeTaskHeader("body", "{\"y\":{{y}}}"),
             Map.of());
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 201);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 201);
+
+    verify(
         postRequestedFor(urlEqualTo("/token"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("Accept", equalTo("application/json"))
@@ -659,7 +737,7 @@ public class ProcessIntegrationTest {
                 equalToJson(
                     "{\"client_id\":\"someClientId\", \"client_secret\": \"someSecret\",  \"audience\": \"someAudience\",  \"grant_type\": \"client_credentials\"}")));
 
-    WIRE_MOCK_RULE.verify(
+    verify(
         postRequestedFor(urlEqualTo("/api/1"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson("{\"y\":2}")));
@@ -680,8 +758,7 @@ public class ProcessIntegrationTest {
     taskCustomizer.accept(processBuilder);
     processBuilder.endEvent();
 
-    TEST_RULE
-        .getClient()
+    client
         .newDeployCommand()
         .addProcessModel(processBuilder.done(), "process.bpmn")
         .requestTimeout(Duration.ofSeconds(10))
@@ -689,8 +766,7 @@ public class ProcessIntegrationTest {
         .join();
 
     return
-        TEST_RULE
-            .getClient()
+        client
             .newCreateInstanceCommand()
             .bpmnProcessId("process")
             .latestVersion()
@@ -701,7 +777,7 @@ public class ProcessIntegrationTest {
   }
 
   @Test
-  public void testCustomHeadersCanBeProvided() {
+  public void testCustomHeadersCanBeProvided(WireMockRuntimeInfo wmRuntimeInfo) {
 
     stubFor(put(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
 
@@ -709,14 +785,16 @@ public class ProcessIntegrationTest {
         createInstance(
             serviceTask ->
                 serviceTask
-                    .zeebeTaskHeader("url", WIRE_MOCK_RULE.baseUrl() + "/api")
+                    .zeebeTaskHeader("url", wmRuntimeInfo.getHttpBaseUrl() + "/api")
                     .zeebeTaskHeader("method", "PUT")
                     .zeebeTaskHeader("header-x-lower", "case")
                     .zeebeTaskHeader("HEADER-x-upper", "case"));
 
-    ZeebeTestRule.assertThat(processInstance).isEnded().hasVariable("statusCode", 200);
+    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(processInstance);
 
-    WIRE_MOCK_RULE.verify(
+    BpmnAssert.assertThat(processInstance).isCompleted().hasVariableWithValue("statusCode", 200);
+
+    verify(
         putRequestedFor(urlEqualTo("/api"))
             .withHeader("x-lower", equalTo("case"))
             .withHeader("x-upper", equalTo("case")));

--- a/src/test/java/io/zeebe/http/variables/LocalVariablesProviderTest.java
+++ b/src/test/java/io/zeebe/http/variables/LocalVariablesProviderTest.java
@@ -1,10 +1,10 @@
 package io.zeebe.http.variables;
 
 import io.zeebe.http.ZeebeHttpWorkerConfig;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -17,7 +17,7 @@ public class LocalVariablesProviderTest {
   private ZeebeHttpWorkerConfig config;
   private EnvironmentVariablesProvider provider;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     config = mock(ZeebeHttpWorkerConfig.class);
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+    <logger name="io.zeebe" level="debug" />
+    <logger name="org.springframework.core " level="error" />
+    <logger name="org.springframework.beans" level="error" />
+    <logger name="org.springframework.context" level="error" />
+    <logger name="org.springframework.transaction" level="error" />
+    <logger name="org.springframework.web" level="error" />
+    <logger name="org.springframework.test" level="error" />
+    <logger name="org.hibernate" level="error" />
+</configuration>


### PR DESCRIPTION
* migrate the tests to JUnint5 and Zeebe-Spring-Test
* remove the prefetching of the variable on startup because it causes issues in the tests
* bump to Java 17
* bump spring-zeebe to 8.0.3
* dump surefire plugin for JUnit5